### PR TITLE
Add segments between particles

### DIFF
--- a/browser-test/index.html
+++ b/browser-test/index.html
@@ -23,13 +23,7 @@
 		<script>
 			const canvas = document.querySelector('canvas');
 
-			console.log(
-				DParticles.createParticlesOnCanvas(
-					canvas,
-					{ nextFrameCaller: fn => requestAnimationFrame(fn), particlesCount: { min: 30, max: 50 } },
-					{ background: [`#000`, `./img.png`], size: { min: 20, max: 25 }, keepAround: true }
-				).currentState.size
-			);
+			console.log(DParticles.createParticlesOnCanvas(canvas, { nextFrameCaller: fn => requestAnimationFrame(fn) }).currentState.size);
 		</script>
 	</body>
 </html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,12 +4,6 @@
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
-		"@types/color-name": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
-			"integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==",
-			"dev": true
-		},
 		"@types/estree": {
 			"version": "0.0.39",
 			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
@@ -26,15 +20,6 @@
 			"version": "0.0.8",
 			"resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-0.0.8.tgz",
 			"integrity": "sha512-auApPaJf3NPfe18hSoJkp8EbZzer2ISk7o8mCC3M9he/a04+gbMF97NkpD2S8riMGvm4BMRI59/SZQSaLTKpsQ==",
-			"dev": true,
-			"requires": {
-				"@types/node": "*"
-			}
-		},
-		"@types/through2": {
-			"version": "2.0.34",
-			"resolved": "https://registry.npmjs.org/@types/through2/-/through2-2.0.34.tgz",
-			"integrity": "sha512-nhRG8+RuG/L+0fAZBQYaRflXKjTrHOKH8MFTChnf+dNVMxA3wHYYrfj0tztK0W51ABXjGfRCDc0vRkecCOrsow==",
 			"dev": true,
 			"requires": {
 				"@types/node": "*"
@@ -97,16 +82,6 @@
 			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
 			"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
 			"dev": true
-		},
-		"ansi-styles": {
-			"version": "4.2.1",
-			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-			"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
-			"dev": true,
-			"requires": {
-				"@types/color-name": "^1.1.1",
-				"color-convert": "^2.0.1"
-			}
 		},
 		"arch": {
 			"version": "2.1.1",
@@ -221,16 +196,6 @@
 			"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
 			"dev": true
 		},
-		"chalk": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-			"integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
-			"dev": true,
-			"requires": {
-				"ansi-styles": "^4.1.0",
-				"supports-color": "^7.1.0"
-			}
-		},
 		"cli-boxes": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-1.0.0.tgz",
@@ -263,21 +228,6 @@
 					}
 				}
 			}
-		},
-		"color-convert": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-			"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-			"dev": true,
-			"requires": {
-				"color-name": "~1.1.4"
-			}
-		},
-		"color-name": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-			"dev": true
 		},
 		"compressible": {
 			"version": "2.0.18",
@@ -338,58 +288,6 @@
 			"integrity": "sha1-DPaLud318r55YcOoUXjLhdunjLQ=",
 			"dev": true
 		},
-		"cross-env": {
-			"version": "6.0.3",
-			"resolved": "https://registry.npmjs.org/cross-env/-/cross-env-6.0.3.tgz",
-			"integrity": "sha512-+KqxF6LCvfhWvADcDPqo64yVIB31gv/jQulX2NGzKS/g3GEVz6/pt4wjHFtFWsHMddebWD/sDthJemzM4MaAag==",
-			"dev": true,
-			"requires": {
-				"cross-spawn": "^7.0.0"
-			},
-			"dependencies": {
-				"cross-spawn": {
-					"version": "7.0.1",
-					"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.1.tgz",
-					"integrity": "sha512-u7v4o84SwFpD32Z8IIcPZ6z1/ie24O6RU3RbtL5Y316l3KuHVPx9ItBgWQ6VlfAFnRnTtMUrsQ9MUUTuEZjogg==",
-					"dev": true,
-					"requires": {
-						"path-key": "^3.1.0",
-						"shebang-command": "^2.0.0",
-						"which": "^2.0.1"
-					}
-				},
-				"path-key": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.0.tgz",
-					"integrity": "sha512-8cChqz0RP6SHJkMt48FW0A7+qUOn+OsnOsVtzI59tZ8m+5bCSk7hzwET0pulwOM2YMn9J1efb07KB9l9f30SGg==",
-					"dev": true
-				},
-				"shebang-command": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
-					"integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-					"dev": true,
-					"requires": {
-						"shebang-regex": "^3.0.0"
-					}
-				},
-				"shebang-regex": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
-					"integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-					"dev": true
-				},
-				"which": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/which/-/which-2.0.1.tgz",
-					"integrity": "sha512-N7GBZOTswtB9lkQBZA4+zAXrjEIWAUOB93AvzUiudRzRxhUdLURQ7D/gAIMY1gatT/LTbmbcv8SiYazy3eYB7w==",
-					"dev": true,
-					"requires": {
-						"isexe": "^2.0.0"
-					}
-				}
-			}
-		},
 		"cross-spawn": {
 			"version": "5.1.0",
 			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
@@ -399,15 +297,6 @@
 				"lru-cache": "^4.0.1",
 				"shebang-command": "^1.2.0",
 				"which": "^1.2.9"
-			}
-		},
-		"debug": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-			"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-			"dev": true,
-			"requires": {
-				"ms": "^2.1.1"
 			}
 		},
 		"deep-extend": {
@@ -500,18 +389,6 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
 			"integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
-			"dev": true
-		},
-		"has-flag": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-			"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-			"dev": true
-		},
-		"inherits": {
-			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
 			"dev": true
 		},
 		"ini": {
@@ -614,12 +491,6 @@
 			"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
 			"dev": true
 		},
-		"ms": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-			"dev": true
-		},
 		"negotiator": {
 			"version": "0.6.2",
 			"resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.2.tgz",
@@ -705,17 +576,6 @@
 				"ini": "~1.3.0",
 				"minimist": "^1.2.0",
 				"strip-json-comments": "~2.0.1"
-			}
-		},
-		"readable-stream": {
-			"version": "3.5.0",
-			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.5.0.tgz",
-			"integrity": "sha512-gSz026xs2LfxBPudDuI41V1lka8cxg64E66SGe78zJlsUofOg/yqwezdIcdfwik6B4h8LFmWPA9ef9X3FiNFLA==",
-			"dev": true,
-			"requires": {
-				"inherits": "^2.0.3",
-				"string_decoder": "^1.1.1",
-				"util-deprecate": "^1.0.1"
 			}
 		},
 		"registry-auth-token": {
@@ -1012,15 +872,6 @@
 				"strip-ansi": "^4.0.0"
 			}
 		},
-		"string_decoder": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-			"integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-			"dev": true,
-			"requires": {
-				"safe-buffer": "~5.2.0"
-			}
-		},
 		"strip-ansi": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
@@ -1048,15 +899,6 @@
 			"integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
 			"dev": true
 		},
-		"supports-color": {
-			"version": "7.1.0",
-			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-			"integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
-			"dev": true,
-			"requires": {
-				"has-flag": "^4.0.0"
-			}
-		},
 		"term-size": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/term-size/-/term-size-1.2.0.tgz",
@@ -1064,15 +906,6 @@
 			"dev": true,
 			"requires": {
 				"execa": "^0.7.0"
-			}
-		},
-		"through2": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/through2/-/through2-3.0.1.tgz",
-			"integrity": "sha512-M96dvTalPT3YbYLaKaCuwu+j06D/8Jfib0o/PxbVt6Amhv3dUAtW6rTV1jPgJSBG83I/e04Y6xkVdVhSRhi0ww==",
-			"dev": true,
-			"requires": {
-				"readable-stream": "2 || 3"
 			}
 		},
 		"tslib": {
@@ -1105,12 +938,6 @@
 			"requires": {
 				"punycode": "^2.1.0"
 			}
-		},
-		"util-deprecate": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-			"dev": true
 		},
 		"vary": {
 			"version": "1.1.2",
@@ -1159,18 +986,6 @@
 			"requires": {
 				"flat": "^5.0.0",
 				"stacktrace-js": "^2.0.1"
-			}
-		},
-		"zip-tap-reporter": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/zip-tap-reporter/-/zip-tap-reporter-2.0.0.tgz",
-			"integrity": "sha512-Ifc+TK0PFOo5ekMK2Picoq52kxk4f51o4mFvADpF4C4gFlTa7ZoVKP1tDOlghEIDaqBsu3LC+MKg1BY4C5wdmg==",
-			"dev": true,
-			"requires": {
-				"@types/through2": "^2.0.34",
-				"chalk": "^3.0.0",
-				"debug": "^4.1.1",
-				"through2": "^3.0.1"
 			}
 		}
 	}

--- a/package.json
+++ b/package.json
@@ -6,9 +6,10 @@
 	"module": "dist/build.esm.js",
 	"typings": "typings/index.d.ts",
 	"scripts": {
-		"build": "cross-env NODE_ENV=production rollup -c && tsc",
-		"test": "cross-env NODE_ENV=development rollup -c",
-		"dev": "rollup -c --environment=BROWSER_TEST,NODE_ENV:production",
+		"build": "rollup -c --environment=NODE_ENV:production && tsc",
+		"test": "rollup -c",
+		"test:unit": "rollup -c --environment=TEST_TYPE:unit",
+		"dev": "rollup -c --environment=TEST_TYPE:browser,NODE_ENV:production",
 		"lint": "prettier --write \"./**\"",
 		"lint:test": "prettier --check \"./**\"",
 		"preversion": "npm run test && npm run lint:test && npm run build",
@@ -32,7 +33,6 @@
 	"license": "MIT",
 	"devDependencies": {
 		"acorn": "^7.1.0",
-		"cross-env": "^6.0.3",
 		"deepmerge": "^4.2.2",
 		"prettier": "^1.19.1",
 		"rollup": "^1.29.1",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -8,7 +8,8 @@ import globFiles from 'rollup-plugin-glob-files';
 const sourcemap = true;
 const prod = process.env.NODE_ENV === 'production';
 const watching = process.env.ROLLUP_WATCH;
-const browserTest = process.env.BROWSER_TEST;
+const browserTest = process.env.TEST_TYPE === 'browser';
+const unitTest = process.env.TEST_TYPE === 'unit';
 
 const sharedOutputOptions = {
 	sourcemap,
@@ -28,7 +29,7 @@ export default {
 		!prod &&
 			globFiles({
 				key: `@tests`,
-				include: `./tests/**/*.ts`,
+				include: unitTest ? `./tests/unit/**/*.ts` : `./tests/**/*.ts`,
 				justImport: true,
 			}),
 		resolve(),

--- a/src/canvas.ts
+++ b/src/canvas.ts
@@ -43,7 +43,7 @@ export function createParticlesOnCanvas(element: HTMLCanvasElement, configOption
 	});
 
 	function drawParticle(particle: Particle, img?: HTMLOrSVGImageElement) {
-		if (!particle.options.keepAround) ctx.globalAlpha = setAlpha(particle.age, particle.lifespan);
+		// if (!particle.options.keepAround) ctx.globalAlpha = setAlpha(particle.age, particle.lifespan);
 
 		if (img) {
 			ctx.drawImage(img, particle.positionX * width(), particle.positionY * height(), particle.size, particle.size);

--- a/src/canvas.ts
+++ b/src/canvas.ts
@@ -43,8 +43,6 @@ export function createParticlesOnCanvas(element: HTMLCanvasElement, configOption
 	});
 
 	function drawParticle(particle: Particle, img?: HTMLOrSVGImageElement) {
-		// if (!particle.options.keepAround) ctx.globalAlpha = setAlpha(particle.age, particle.lifespan);
-
 		if (img) {
 			ctx.drawImage(img, particle.positionX * width(), particle.positionY * height(), particle.size, particle.size);
 		} else {
@@ -63,15 +61,6 @@ export function createParticlesOnCanvas(element: HTMLCanvasElement, configOption
 		ctx.strokeStyle = segment.stroke;
 		ctx.lineWidth = segment.width;
 		ctx.stroke();
-	}
-
-	function setAlpha(age: number, lifespan: number): number {
-		if (age < 10) return age * 0.1;
-
-		const cyclesLeft = lifespan - age;
-		if (cyclesLeft < 10) return cyclesLeft * 0.1;
-
-		return 1;
 	}
 
 	function isImage(background: string) {

--- a/src/canvas.ts
+++ b/src/canvas.ts
@@ -1,6 +1,7 @@
 import { ConfigOptions } from './interfaces';
 import { ParticleOptions, Particle } from './particle';
 import { DecentralizedParticles } from './core';
+import { Segment } from './segment';
 
 export function createParticlesOnCanvas(element: HTMLCanvasElement, configOptions?: ConfigOptions, particleOptions?: ParticleOptions) {
 	const ctx = element.getContext(`2d`);
@@ -35,6 +36,11 @@ export function createParticlesOnCanvas(element: HTMLCanvasElement, configOption
 
 		particle.onUpdate(() => drawParticle(particle, img));
 	});
+	particles.createSegment(segment => {
+		drawSegment(segment);
+
+		segment.onUpdate(() => drawSegment(segment));
+	});
 
 	function drawParticle(particle: Particle, img?: HTMLOrSVGImageElement) {
 		if (!particle.options.keepAround) ctx.globalAlpha = setAlpha(particle.age, particle.lifespan);
@@ -47,6 +53,16 @@ export function createParticlesOnCanvas(element: HTMLCanvasElement, configOption
 			ctx.fillStyle = particle.background;
 			ctx.fill();
 		}
+	}
+
+	function drawSegment(segment: Segment) {
+		ctx.beginPath();
+
+		ctx.moveTo(segment.positionX1 * width(), segment.positionY1 * height());
+		ctx.lineTo(segment.positionX2 * width(), segment.positionY2 * height());
+		ctx.strokeStyle = segment.stroke;
+		ctx.lineWidth = segment.width;
+		ctx.stroke();
 	}
 
 	function setAlpha(age: number, lifespan: number): number {

--- a/src/core.ts
+++ b/src/core.ts
@@ -4,21 +4,25 @@ import { Particle, ParticleOptions } from './particle';
 import defaultConfigOptions from './default-config-options';
 import { getRndInteger } from './utils';
 import defaultParticleOptions from './default-particle-options';
+import { SegmentOptions } from './segment';
 
 type MaybePromiseFunction = () => void | Promise<void>;
 
 export class DecentralizedParticles {
 	config: ConfigOptions;
 	particleOptions: ParticleOptions;
+	segmentOptions: SegmentOptions;
 
 	private currentState: Map<string, Particle>;
 	private particleCreator: ParticleCreator;
 	private callBeforeUpdate: MaybePromiseFunction[] = [];
 	private callAfterUpdate: MaybePromiseFunction[] = [];
 
-	constructor(configOptions?: ConfigOptions, particleOptions?: ParticleOptions) {
+	constructor(configOptions?: ConfigOptions, particleOptions?: ParticleOptions, segmentOptions?: SegmentOptions) {
 		this.config = deepMerge(this.config || defaultConfigOptions, configOptions || {});
 		this.particleOptions = particleOptions;
+
+		if (this.config.segments) this.segmentOptions = segmentOptions;
 
 		this.particleCreator = () => {};
 	}

--- a/src/default-config-options.ts
+++ b/src/default-config-options.ts
@@ -8,6 +8,7 @@ const defaultConfig: ConfigOptions = {
 	nextFrameCaller: fn => {
 		setTimeout(fn, 16);
 	},
+	segments: true,
 };
 
 export default defaultConfig;

--- a/src/default-config-options.ts
+++ b/src/default-config-options.ts
@@ -9,7 +9,7 @@ const defaultConfig: ConfigOptions = {
 		setTimeout(fn, 16);
 	},
 	segments: true,
-	segmentStrength: 0.05,
+	segmentStrength: 0.254,
 };
 
 export default defaultConfig;

--- a/src/default-config-options.ts
+++ b/src/default-config-options.ts
@@ -2,8 +2,8 @@ import { ConfigOptions } from './interfaces';
 
 const defaultConfig: ConfigOptions = {
 	particlesCount: {
-		max: 200,
-		min: 150,
+		max: 50,
+		min: 30,
 	},
 	nextFrameCaller: fn => {
 		setTimeout(fn, 16);

--- a/src/default-config-options.ts
+++ b/src/default-config-options.ts
@@ -9,6 +9,7 @@ const defaultConfig: ConfigOptions = {
 		setTimeout(fn, 16);
 	},
 	segments: true,
+	segmentStrength: 0.05,
 };
 
 export default defaultConfig;

--- a/src/default-config-options.ts
+++ b/src/default-config-options.ts
@@ -2,14 +2,14 @@ import { ConfigOptions } from './interfaces';
 
 const defaultConfig: ConfigOptions = {
 	particlesCount: {
-		max: 50,
-		min: 30,
+		max: 230,
+		min: 200,
 	},
 	nextFrameCaller: fn => {
 		setTimeout(fn, 16);
 	},
 	segments: true,
-	segmentStrength: 0.254,
+	segmentStrength: 0.11,
 };
 
 export default defaultConfig;

--- a/src/default-particle-options.ts
+++ b/src/default-particle-options.ts
@@ -2,8 +2,8 @@ import { ParticleOptions } from './particle';
 
 const defaultParticleOptions: ParticleOptions = {
 	size: {
-		max: 7,
-		min: 3,
+		max: 10,
+		min: 9,
 	},
 	background: `#ddd`,
 	lifespan: {

--- a/src/default-particle-options.ts
+++ b/src/default-particle-options.ts
@@ -2,17 +2,17 @@ import { ParticleOptions } from './particle';
 
 const defaultParticleOptions: ParticleOptions = {
 	size: {
-		max: 10,
-		min: 9,
+		max: 5,
+		min: 3,
 	},
-	background: `#ddd`,
+	background: `#777`,
 	lifespan: {
-		max: 400,
-		min: 300,
+		max: 5000,
+		min: 4900,
 	},
 	speed: {
-		min: 0.0005,
-		max: 0.0009,
+		min: 0.0003,
+		max: 0.0004,
 	},
 	keepAround: false,
 };

--- a/src/default-segment-options.ts
+++ b/src/default-segment-options.ts
@@ -3,8 +3,8 @@ import { SegmentOptions } from './segment';
 const defaultSegmentOptions: SegmentOptions = {
 	stroke: `#444`,
 	width: {
-		min: 2,
-		max: 2.2,
+		min: 1.5,
+		max: 1.6,
 	},
 };
 

--- a/src/default-segment-options.ts
+++ b/src/default-segment-options.ts
@@ -1,10 +1,10 @@
 import { SegmentOptions } from './segment';
 
 const defaultSegmentOptions: SegmentOptions = {
-	stroke: `#444`,
+	stroke: `#bbb`,
 	width: {
-		min: 1.5,
-		max: 1.6,
+		min: 0.5,
+		max: 0.5,
 	},
 };
 

--- a/src/default-segment-options.ts
+++ b/src/default-segment-options.ts
@@ -1,0 +1,12 @@
+import { SegmentOptions } from './segment';
+
+const defaultSegmentOptions: SegmentOptions = {
+	stroke: `#eee`,
+	strength: 0.4,
+	width: {
+		min: 3,
+		max: 5,
+	},
+};
+
+export default defaultSegmentOptions;

--- a/src/default-segment-options.ts
+++ b/src/default-segment-options.ts
@@ -2,7 +2,6 @@ import { SegmentOptions } from './segment';
 
 const defaultSegmentOptions: SegmentOptions = {
 	stroke: `#eee`,
-	strength: 0.4,
 	width: {
 		min: 3,
 		max: 5,

--- a/src/default-segment-options.ts
+++ b/src/default-segment-options.ts
@@ -1,10 +1,10 @@
 import { SegmentOptions } from './segment';
 
 const defaultSegmentOptions: SegmentOptions = {
-	stroke: `#eee`,
+	stroke: `#444`,
 	width: {
-		min: 3,
-		max: 5,
+		min: 2,
+		max: 2.2,
 	},
 };
 

--- a/src/group-particles.ts
+++ b/src/group-particles.ts
@@ -1,5 +1,37 @@
 import { Particle } from './particle';
 
+function loopFromIndex<T>(array: T[], startIndex: number, cb: (val: T, index: number) => void) {
+	for (let x = startIndex; x < array.length; x++) {
+		cb(array[x], x);
+	}
+}
+
+function makePositive(n: number): number {
+	if (n < 0) return n * -1;
+	return n;
+}
+
+function hypotenuse(n1: number, n2: number) {
+	return Math.sqrt(n1 * n1 + n2 * n2);
+}
+
+function getDistanceBetween(particle1: Particle, particle2: Particle): number {
+	const distanceX = makePositive(particle1.positionX - particle2.positionX);
+	const distanceY = makePositive(particle1.positionY - particle2.positionY);
+
+	return hypotenuse(distanceX, distanceY);
+}
+
 export default (particles: Particle[], strength: number): [Particle, Particle][] => {
-	return [];
+	const result: [Particle, Particle][] = [];
+
+	particles.forEach((particle, index) => {
+		loopFromIndex(particles, index + 1, proposition => {
+			const distanceBetween = getDistanceBetween(particle, proposition);
+
+			if (distanceBetween <= strength) result.push([particle, proposition]);
+		});
+	});
+
+	return result;
 };

--- a/src/group-particles.ts
+++ b/src/group-particles.ts
@@ -1,0 +1,5 @@
+import { Particle } from './particle';
+
+export default (particles: Particle[], strength: number): [Particle, Particle][] => {
+	return [];
+};

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -5,6 +5,7 @@ export interface ConfigOptions {
 	particlesCount?: RangeValue;
 	nextFrameCaller?: (fn: () => Promise<void> | void) => void;
 	segments?: boolean;
+	segmentStrength?: number; // between 0 and 1
 }
 
 export type UpdateHook = (updatedProperties: Particle) => void | Promise<void>;

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -1,5 +1,6 @@
 import { Particle } from './particle';
 import { RangeValue } from './background-interfaces';
+import { Segment } from './segment';
 
 export interface ConfigOptions {
 	particlesCount?: RangeValue;
@@ -13,3 +14,4 @@ export interface ParticleHooks {
 	update: UpdateHook;
 }
 export type ParticleCreator = (particle: Particle) => Promise<void> | void | (() => void) | Promise<() => void>;
+export type SegmentCreator = (segment: Segment) => Promise<void> | void | (() => void) | Promise<() => void>;

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -4,6 +4,7 @@ import { RangeValue } from './background-interfaces';
 export interface ConfigOptions {
 	particlesCount?: RangeValue;
 	nextFrameCaller?: (fn: () => Promise<void> | void) => void;
+	segments?: boolean;
 }
 
 export type UpdateHook = (updatedProperties: Particle) => void | Promise<void>;

--- a/src/particle.ts
+++ b/src/particle.ts
@@ -9,6 +9,8 @@ export interface ParticleOptions {
 	lifespan?: RangeValue; // Units are in updates
 	speed?: RangeValue; // Movements per update
 	keepAround?: boolean;
+	startPositionX?: number;
+	startPositionY?: number;
 }
 
 export class Particle {
@@ -38,8 +40,8 @@ export class Particle {
 		this.options = deepMerge(defaultParticleOptions, options || {});
 
 		this.id = randomString(20);
-		this.positionX = Math.random();
-		this.positionY = Math.random();
+		this.positionX = options.startPositionX || Math.random();
+		this.positionY = options.startPositionY || Math.random();
 		this.initialPositionX = this.positionX;
 		this.initialPositionY = this.positionY;
 

--- a/src/particle.ts
+++ b/src/particle.ts
@@ -40,8 +40,8 @@ export class Particle {
 		this.options = deepMerge(defaultParticleOptions, options || {});
 
 		this.id = randomString(20);
-		this.positionX = options.startPositionX || Math.random();
-		this.positionY = options.startPositionY || Math.random();
+		this.positionX = this.options.startPositionX || Math.random();
+		this.positionY = this.options.startPositionY || Math.random();
 		this.initialPositionX = this.positionX;
 		this.initialPositionY = this.positionY;
 

--- a/src/particle.ts
+++ b/src/particle.ts
@@ -1,5 +1,5 @@
 import { RangeValue, AnyFunction } from './background-interfaces';
-import { randomString, getRndInteger, getRightTriangleSides } from './utils';
+import { randomString, getRndInteger, getRightTriangleSides, chooseOption } from './utils';
 import deepMerge from 'deepmerge';
 import defaultParticleOptions from './default-particle-options';
 
@@ -49,10 +49,7 @@ export class Particle {
 		this.size = getRndInteger(this.options.size.min, this.options.size.max);
 		this.speed = getRndInteger(this.options.speed.min, this.options.speed.max);
 
-		if (Array.isArray(this.options.background)) {
-			if (!this.options.background.length) throw new Error(`'options.background' cannot be an empty array.`);
-			this.background = this.options.background[getRndInteger(0, this.options.background.length - 1)];
-		} else this.background = this.options.background;
+		this.background = chooseOption(this.options.background);
 
 		this.setDestination();
 	}

--- a/src/segment.ts
+++ b/src/segment.ts
@@ -1,6 +1,8 @@
 import { Particle } from './particle';
 import { RangeValue, AnyFunction } from './background-interfaces';
 import { chooseOption, getRndInteger } from './utils';
+import deepMerge from 'deepmerge';
+import defaultSegmentOptions from './default-segment-options';
 
 export interface SegmentOptions {
 	stroke?: string[] | string;
@@ -28,7 +30,7 @@ export class Segment {
 		if (!(startParticle instanceof Particle && endParticle instanceof Particle))
 			throw new Error(errBase + `must be of type '[Particle, Particle]'`);
 
-		this.options = options;
+		this.options = deepMerge(defaultSegmentOptions, options);
 		this.startParticle = startParticle;
 		this.endParticle = endParticle;
 

--- a/src/segment.ts
+++ b/src/segment.ts
@@ -1,8 +1,9 @@
 import { Particle } from './particle';
+import { RangeValue } from './background-interfaces';
 
 export interface SegmentOptions {
 	stroke?: string;
-	width?: string;
+	width?: RangeValue;
 	strength?: number; // between 0 and 1
 }
 

--- a/src/segment.ts
+++ b/src/segment.ts
@@ -1,0 +1,23 @@
+import { Particle } from './particle';
+
+export interface SegmentOptions {
+	stroke?: string;
+	width?: string;
+	strength?: number; // between 0 and 1
+}
+
+export class Segment {
+	options: SegmentOptions;
+	startParticle: Particle;
+	endParticle: Particle;
+
+	constructor(startParticle: Particle, endParticle: Particle, options?: SegmentOptions) {
+		const errBase = `The first param to 'Segment' `;
+		if (!(startParticle instanceof Particle && endParticle instanceof Particle))
+			throw new Error(errBase + `must be of type '[Particle, Particle]'`);
+
+		this.options = options;
+		this.startParticle = startParticle;
+		this.endParticle = endParticle;
+	}
+}

--- a/src/segment.ts
+++ b/src/segment.ts
@@ -1,8 +1,9 @@
 import { Particle } from './particle';
-import { RangeValue } from './background-interfaces';
+import { RangeValue, AnyFunction } from './background-interfaces';
+import { chooseOption, getRndInteger } from './utils';
 
 export interface SegmentOptions {
-	stroke?: string;
+	stroke?: string[] | string;
 	width?: RangeValue;
 	strength?: number; // between 0 and 1
 }
@@ -11,6 +12,16 @@ export class Segment {
 	options: SegmentOptions;
 	startParticle: Particle;
 	endParticle: Particle;
+	stroke: string;
+	width: number;
+
+	positionX1: number;
+	positionX2: number;
+	positionY1: number;
+	positionY2: number;
+
+	private callOnUpdate: AnyFunction[] = [];
+	private callOnDestroy: AnyFunction[] = [];
 
 	constructor(startParticle: Particle, endParticle: Particle, options?: SegmentOptions) {
 		const errBase = `The first param to 'Segment' `;
@@ -20,5 +31,27 @@ export class Segment {
 		this.options = options;
 		this.startParticle = startParticle;
 		this.endParticle = endParticle;
+
+		this.stroke = chooseOption(this.options.stroke);
+		this.width = getRndInteger(this.options.width.min, this.options.width.max);
+	}
+
+	triggerUpdate() {
+		this.positionX1 = this.startParticle.positionX;
+		this.positionX2 = this.endParticle.positionX;
+		this.positionY1 = this.startParticle.positionY;
+		this.positionY2 = this.endParticle.positionY;
+
+		this.callOnUpdate.forEach(fn => fn());
+	}
+	destroy() {
+		this.callOnDestroy.forEach(fn => fn());
+	}
+
+	onUpdate(fn: AnyFunction) {
+		this.callOnUpdate.push(fn);
+	}
+	onDestroy(fn: AnyFunction) {
+		this.callOnDestroy.push(fn);
 	}
 }

--- a/src/segment.ts
+++ b/src/segment.ts
@@ -1,6 +1,6 @@
 import { Particle } from './particle';
 import { RangeValue, AnyFunction } from './background-interfaces';
-import { chooseOption, getRndInteger } from './utils';
+import { chooseOption, getRndInteger, randomString } from './utils';
 import deepMerge from 'deepmerge';
 import defaultSegmentOptions from './default-segment-options';
 
@@ -15,6 +15,7 @@ export class Segment {
 	endParticle: Particle;
 	stroke: string;
 	width: number;
+	id: string;
 
 	positionX1: number;
 	positionX2: number;
@@ -35,6 +36,11 @@ export class Segment {
 
 		this.stroke = chooseOption(this.options.stroke);
 		this.width = getRndInteger(this.options.width.min, this.options.width.max);
+
+		this.id = randomString(20);
+
+		this.startParticle.onDestroy(() => this.destroy());
+		this.endParticle.onDestroy(() => this.destroy());
 	}
 
 	triggerUpdate() {

--- a/src/segment.ts
+++ b/src/segment.ts
@@ -30,7 +30,7 @@ export class Segment {
 		if (!(startParticle instanceof Particle && endParticle instanceof Particle))
 			throw new Error(errBase + `must be of type '[Particle, Particle]'`);
 
-		this.options = deepMerge(defaultSegmentOptions, options);
+		this.options = deepMerge(defaultSegmentOptions, options || {});
 		this.startParticle = startParticle;
 		this.endParticle = endParticle;
 

--- a/src/segment.ts
+++ b/src/segment.ts
@@ -7,7 +7,6 @@ import defaultSegmentOptions from './default-segment-options';
 export interface SegmentOptions {
 	stroke?: string[] | string;
 	width?: RangeValue;
-	strength?: number; // between 0 and 1
 }
 
 export class Segment {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -31,3 +31,10 @@ export function getRightTriangleSides(hypotenuse: number, theta: number) {
 		adjacent: Math.cos(theta) * hypotenuse,
 	};
 }
+
+export function chooseOption<T>(val: T[] | T): T {
+	if (Array.isArray(val)) {
+		if (!val.length) throw new Error(`Array cannot be empty`);
+		return val[getRndInteger(0, val.length - 1)];
+	} else return val;
+}

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -1,8 +1,8 @@
 import { DecentralizedParticles } from '../src';
 import { describe } from 'zip-tap';
 
-describe(`sayHello`, it => {
-	it(`sayHello should return a gretting`, () => {
+describe(`sayHello`, async it => {
+	await it(`sayHello should return a gretting`, () => {
 		return new Promise(resolve => {
 			const particles = new DecentralizedParticles();
 			particles.start();

--- a/tests/unit/group-particles.test.ts
+++ b/tests/unit/group-particles.test.ts
@@ -1,0 +1,49 @@
+import { describe } from 'zip-tap';
+import { Particle } from '../../src/particle';
+import groupParticles from '../../src/group-particles';
+
+describe(`group-particles`, it => {
+	it(`should group the particles`, expect => {
+		const particles = [
+			new Particle({
+				startPositionX: 0.5,
+				startPositionY: 0.5,
+			}),
+			new Particle({
+				startPositionX: 0.5,
+				startPositionY: 0.4,
+			}),
+			new Particle({
+				startPositionX: 0.4,
+				startPositionY: 0.5,
+			}),
+			new Particle({
+				startPositionX: 0.3,
+				startPositionY: 0.3,
+			}),
+			new Particle({
+				startPositionX: 0.2,
+				startPositionY: 0.3,
+			}),
+			new Particle({
+				startPositionX: 0.3,
+				startPositionY: 0.4,
+			}),
+		];
+
+		const groups = [
+			[particles[0], particles[1]],
+			[particles[0], particles[2]],
+			[particles[0], particles[5]],
+			[particles[1], particles[2]],
+			[particles[1], particles[5]],
+			[particles[2], particles[3]],
+			[particles[2], particles[5]],
+			[particles[3], particles[4]],
+			[particles[3], particles[5]],
+			[particles[4], particles[5]],
+		];
+
+		expect(groupParticles(particles, 1.5)).toMatchObject(groups);
+	});
+});

--- a/tests/unit/group-particles.test.ts
+++ b/tests/unit/group-particles.test.ts
@@ -34,16 +34,16 @@ describe(`group-particles`, it => {
 		const groups = [
 			[particles[0], particles[1]],
 			[particles[0], particles[2]],
-			[particles[0], particles[5]],
 			[particles[1], particles[2]],
 			[particles[1], particles[5]],
-			[particles[2], particles[3]],
 			[particles[2], particles[5]],
 			[particles[3], particles[4]],
 			[particles[3], particles[5]],
 			[particles[4], particles[5]],
 		];
 
-		expect(groupParticles(particles, 1.5)).toMatchObject(groups);
+		const actual = groupParticles(particles, 0.2);
+
+		expect(actual).toMatchObject(groups);
 	});
 });


### PR DESCRIPTION
Closes #2 

- [x] Create a Segment class
- [x] Add default options
- [x] Make the Segment move around via a `triggerUpdate` method
- [x] Allow enabling segments in the `ConfigOptions`
- [x] Build a module that takes in an array of x,y coords and returns them grouped together
- [x] Implement the latter module in `Core`